### PR TITLE
added check for module as well as require for node environment

### DIFF
--- a/xls.js
+++ b/xls.js
@@ -3,7 +3,7 @@
 /*jshint eqnull:true, funcscope:true */
 var XLS = {};
 (function(XLS){
-if(typeof require !== 'undefined') {
+if(typeof module !== "undefined" && typeof require !== 'undefined') {
 	if(typeof cptable === 'undefined') var cptable = require('codepage');
 	var current_codepage = 1252, current_cptable = cptable[1252];
 }
@@ -823,7 +823,7 @@ function parse_PropertySetStream(file, PIDSI) {
 	return rval;
 }
 /* [MS-CFB] v20130118 */
-if(typeof require !== "undefined") CFB = require('cfb');
+if(typeof module !== "undefined" && typeof require !== 'undefined') CFB = require('cfb');
 else var CFB = (function(){
 var exports = {};
 function parse(file) {


### PR DESCRIPTION
Hi - thanks for the work on this, it's been a life saver for me this week! Hope this is useful:

When using requireJS in the browser, it attempts to load modules defined
by require(). Not sure if these can be configured to load in browser too
but quick fix is just to add extra check to ensure node environment.
