### PR TITLE
Fix a variable is undefined forever

### DIFF
--- a/xls.js
+++ b/xls.js
@@ -5,7 +5,7 @@ var XLS = {};
 (function(XLS){
 XLS.version = '0.6.16';
 if(typeof module !== "undefined" && typeof require !== 'undefined') {
-	if(typeof cptable === 'undefined') var cptable = require('codepage');
+	if(typeof cptable === 'undefined') cptable = require('codepage');
 	var current_codepage = 1252, current_cptable = cptable[1252];
 }
 function reset_cp() {


### PR DESCRIPTION
The variable captable will be undefined forever unless remove the declaration, because the "var cptable=xxx" will create a undefined variable in the first by javascript interpreter.
