### PR TITLE
Add bower.json to main branch to resolve injection issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "js-xls",
+  "homepage": "https://github.com/SheetJS/js-xls",
+  "main": "dist/xls.js",
+  "version": "0.7.0",
+  "ignore": [
+        "bin",
+        "bits",
+        "misc",
+        "**/.*"
+    ],
+    "keywords": [
+        "xls",
+        "js-xls"
+    ]
+}


### PR DESCRIPTION
I was having an issue when running my application using the "grunt serve" terminal command. The xls.js file was not being injected due to the missing "main" entry in the bower.json file. This file should be in the main branch so when the code is packaged it is formatted for use on install.
