### PR TITLE
ODT: added support for illustration-index

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"jsdom": "^16.2.2"
 	},
 	"devDependencies": {
+		"mocha": "^8.0.1",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^14.0.20",
 		"glob": "^7.1.6",


### PR DESCRIPTION
Added support for parsing `<text:illustration-index>` and `<text:index-body>` tags. This fixes the previously broken test on file `odt/pandoc/imageIndex.odt`.

Other miscellaneous fixes:
- Added `mocha` as a devDependency (I was unable to run the tests before doing this)
- Added support for `<text:tab>`.

_didn't push straight to master this time :flushed:_