### PR TITLE
fix: rm rtf files over 10mb & skip duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,9 @@ if the file exists, so the content is immaterial and a single letter suffices.
 **Generating `.skip` files**
 
 The script will attempt to open password-protected documents using the password
-"WordJS".  The script will not halt but it will not generate a text file.  With
-a few adjustments, the script can generate `.skip` files for those cases
-
-1. Uncomment [L27-29](https://github.com/SheetJS/js-word/blob/master/generate_txt.ps1#L27-L29) in the script
-2. Comment [L26](https://github.com/SheetJS/js-word/blob/master/generate_txt.ps1#L26) in the script
-3. Rerun the script
-4. Undo Step 1 and 2
-
+"WordJS".  The script will not halt but it will not generate a text file. Instead, 
+an output would be written to terminal indicating a skip and will generate a `.skip` 
+when encountered. 
 
 ## License
 

--- a/cross_ext.ps1
+++ b/cross_ext.ps1
@@ -1,4 +1,5 @@
-$HelpCommand = "Run '.\generate_txt.ps1 -h' to see examples"
+$HelpCommand = "Run '.\cross_ext.ps1 -h' to see examples"
+$ext = ".rtf"
 
 #Check if argument or option is provided
 if ($Args.count -ne 1) {
@@ -11,8 +12,8 @@ if ($Args[0] -match '^-') {
     #Check if option is help
     if ($Args[0] -match '^-[h|H](elp)?$') {
         Write-Output "Usage:
-        .\generate_txt[.ps1] <filePath>
-        .\generate_txt[.ps1] -[h|H[elp]]
+        .\cross_ext[.ps1] <filePath>
+        .\cross_ext[.ps1] -[h|H[elp]]
         Examples:
         filePath = .\test_files\docx\apachepoi
         "
@@ -47,7 +48,7 @@ $CurrAbsPath = @(Get-ChildItem -path $Directory -Recurse -Exclude *.txt, *.skip)
     try {
         $similarAbsPath = Join-Path -Path .\test_files\rtf -ChildPath $parent\$subparent
         $filename = Split-Path $CurrAbsPathI -Leaf
-        $similarAbsFilePath = Resolve-Path (Join-Path -Path $similarAbsPath -ChildPath ($filename+".rtf")) -ErrorAction Stop
+        $similarAbsFilePath = Resolve-Path (Join-Path -Path $similarAbsPath -ChildPath ($filename+$ext)) -ErrorAction Stop
 
         if (Test-Path $similarAbsFilePath -PathType Leaf) {
             continue curr_main
@@ -64,7 +65,7 @@ $CurrAbsPath = @(Get-ChildItem -path $Directory -Recurse -Exclude *.txt, *.skip)
     $Word = New-Object -ComObject Word.Application
     try {
         $Doc = $Word.Documents.Open($CurrAbsPathI, $False, $True, $False, "WordJS", "WordJS")
-        $Doc.SaveAs(($CurrAbsPathI+".rtf"), 6, $False, "", $False, "", $False, $False, $False, $False, $False, $Encoding, $False, $False, $LineEnding)
+        $Doc.SaveAs(($CurrAbsPathI+$ext), 6, $False, "", $False, "", $False, $False, $False, $False, $False, $Encoding, $False, $False, $LineEnding)
         $Doc.Close()
     } catch {
         Write-Output "Skipping (has pwd or cannot edit): $CurrAbsPathI"
@@ -87,6 +88,7 @@ $rtfPath = Join-Path -Path .\test_files\ -ChildPath rtf
 
     # Only keep `.rtf` files that are under 10 mb
     if ((Get-Item $ExtAbsPathI).length -gt 10000kb) {
+        Write-Output "deleting $ExtAbsPathI"
         Remove-Item $ExtAbsPathI
         continue ext_main
     }

--- a/cross_ext.ps1
+++ b/cross_ext.ps1
@@ -88,7 +88,7 @@ $rtfPath = Join-Path -Path .\test_files\ -ChildPath rtf
 
     # Only keep `.rtf` files that are under 10 mb
     if ((Get-Item $ExtAbsPathI).length -gt 10000kb) {
-        Write-Output "deleting $ExtAbsPathI"
+        Write-Output "(Deleting file exceeds 10 mb) $ExtAbsPathI"
         Remove-Item $ExtAbsPathI
         continue ext_main
     }


### PR DESCRIPTION
Small changes to #126 addressing the problems of duplicating `.rtf` generation and deleting `.rtf` files that exceed over 10mb.

This PR also updates the README and adds some comments for code clarification.