### PR TITLE
detect encrypted DOCX files

### DIFF
--- a/src/codecs/DOCX/password.ts
+++ b/src/codecs/DOCX/password.ts
@@ -1,0 +1,5 @@
+import { CFB$Container } from "cfb";
+
+export function parse_cfb(file: CFB$Container) {
+  throw "DOCX password encrypted"
+}

--- a/src/codecs/index.ts
+++ b/src/codecs/index.ts
@@ -1,4 +1,5 @@
 import { read as readCFB, find, CFB$Container } from "cfb";
+import { parse_cfb as parse_DOCX_password } from "./DOCX/password";
 import { parse_cfb as parse_DOCX } from "./DOCX";
 import { parse_cfb as parse_DOC } from "./DOC";
 import { parse_cfb as parse_MHT } from "./MHT";
@@ -11,6 +12,8 @@ import { readFileSync } from "fs";
 import { WJSDoc } from "../types";
 
 export function parse_cfb(file: CFB$Container): WJSDoc {
+  /* MS-OFFCRYPTO 2.1.1 */
+  if(find(file, "/\x06DataSpaces/Version") && find(file, "/\x06DataSpaces/DataSpaceMap")) parse_DOCX_password(file);
   if(find(file, "/WordDocument")) return parse_DOC(file);
   if(find(file, "/CONTENTS")) throw "Unsupported Works WPS file";
   if(find(file, "/MM") || find(file, "/MN0")) throw "Unsupported Works WPS file";


### PR DESCRIPTION
This pull request detects encrypted DOCX files per [these requirements](https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-offcrypto/11dfbc00-031a-44bc-a836-e7b9872438fd).