### PR TITLE
add skeleton for dfs

### DIFF
--- a/src/codecs/HTML/index.ts
+++ b/src/codecs/HTML/index.ts
@@ -5,9 +5,24 @@ export function parse_str(data: string): WJSDoc {
   const dom: JSDOM = new JSDOM(data);
   const doc: WJSDoc = {p:[]};
   const para: WJSPara = {elts:[]};
-  para.elts.push({t: "s", v: dom.window.document.querySelector('body').textContent});
+
+  // Assuming first child is always <html...>
+  const root = dom.window.document.childNodes[0];
+  dfs(root, para);
   doc.p.push(para);
   return doc;
+}
+
+const dfs = (element: ChildNode , para: WJSPara): WJSPara => {
+  element.childNodes.forEach(child => {
+    switch (child.nodeName) {
+      case "P":
+        para.elts.push({t: "s", v: child.textContent});
+      default: /*throw `DOCX table unsuported ${child.nodeName} element`*/
+    }
+    dfs(child, para);
+  })
+  return para;
 }
 
 export function read(data: Buffer): WJSDoc {


### PR DESCRIPTION
This PR adds basic dfs traversal, adding text content from paragraphs
Running `env FMTS=html npm run test` yields
```bash
47 passing (18s)
3 pending
397 failing
```